### PR TITLE
Reconfigure port

### DIFF
--- a/src/pytest_reserial/reserial.py
+++ b/src/pytest_reserial/reserial.py
@@ -28,6 +28,17 @@ class Mode(IntEnum):
     INVALID = 3
 
 
+def reconfigure_port_patch(
+    self: Serial, force_update: bool = False  # pylint: disable=unused-argument
+) -> None:
+    """Don't try to set parameters on the mocked port.
+
+    When changing settings such as timeout, parity, stop bits, etc. the
+    _reconfigure_port method is called. It operates directly on the underlying operating
+    system resource, which doesn't exist in reserial. Therefore, this patch is required.
+    """
+
+
 @pytest.fixture
 def reserial(
     monkeypatch: pytest.MonkeyPatch,
@@ -53,6 +64,7 @@ def reserial(
     monkeypatch.setattr(Serial, "write", write_patch)
     monkeypatch.setattr(Serial, "open", open_patch)
     monkeypatch.setattr(Serial, "close", close_patch)
+    monkeypatch.setattr(Serial, "_reconfigure_port", reconfigure_port_patch)
 
     yield
 

--- a/src/pytest_reserial/reserial.py
+++ b/src/pytest_reserial/reserial.py
@@ -179,8 +179,6 @@ def get_replay_methods(
         ValueError
             If written data does not match recorded data.
         """
-        nonlocal log
-
         if list(data) == log["tx"][: len(data)]:
             log["tx"] = log["tx"][len(data) :]
         else:
@@ -200,7 +198,6 @@ def get_replay_methods(
         Monkeypatch this method over Serial.read to replay traffic. Parameters and
         return values are identical to Serial.read.
         """
-        nonlocal log
         data = log["rx"][:size]
         log["rx"] = log["rx"][size:]
         return bytes(data)
@@ -208,7 +205,7 @@ def get_replay_methods(
     return replay_read, replay_write, replay_open, replay_close
 
 
-# The open/close method patches don't need any nonlocals, so they can stay down here.
+# The open/close method patches don't need access to logs, so they can stay down here.
 def replay_open(self: Serial) -> None:
     """Pretend that port was opened."""
     self.is_open = True
@@ -254,7 +251,6 @@ def get_record_methods(
         Monkeypatch this method over Serial.write to record traffic. Parameters and
         return values are identical to Serial.write.
         """
-        nonlocal log
         log["tx"] += list(data)
         written: int = real_write(self, data)
         return written
@@ -266,7 +262,6 @@ def get_record_methods(
         return values are identical to Serial.read.
         """
         data: bytes = real_read(self, size)
-        nonlocal log
         log["rx"] += list(data)
         return data
 

--- a/tests/test_reserial.py
+++ b/tests/test_reserial.py
@@ -99,3 +99,20 @@ def test_help_message(pytester):
         ]
     )
     assert result.ret == 0
+
+
+def test_change_settings(pytester):
+    pytester.makefile(
+        ".json",
+        test_change_settings='{"test_reserial": {"tx": [], "rx": []}}',
+    )
+    pytester.makepyfile(
+        """
+            import serial
+            def test_reserial(reserial):
+                s = serial.Serial(port="/dev/ttyUSB0")
+                s.timeout = 1
+        """
+    )
+    result = pytester.runpytest("--replay")
+    assert result.ret == 0


### PR DESCRIPTION
Setting port parameters such as timeout, byte size, parity, etc. operates at the operating system resource. Since no such resource exists within the reserial context, it is necessary to patch `serial.Serial._reconfigure_port` to do nothing.