### PR TITLE
Update log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## [0.4.0] - Development
+## [0.4.1] - Development
+
+## [0.4.0] - 2024-05-22
+
+_This release changes the format for traffic log files. Use the provided `update_log.py`-script to update old logs to the new format.
+
+### Changed
+
+- __Breaking__: Store test recordings as JSON Lines instead of JSON ([`2b047d7`](https://github.com/bessman/pytest-reserial/commit/2b047d7cc96a06b201e7d25d316492e079835a61))
+- __Breaking__: Store RX and TX bytes as base64 strings instead of lists ([`2b047d7`](https://github.com/bessman/pytest-reserial/commit/2b047d7cc96a06b201e7d25d316492e079835a61))
+
+### Added
+
+- Add script (`update_log.py`) to convert old log files to new format ([`ca14b9b`](https://github.com/bessman/pytest-reserial/commit/ca14b9be86ced3a58b417dc0d8b14afde97df86d))
+
+### Removed
+
+- Remove optional dependency on jsbeautifier ([`0ba5414`](https://github.com/bessman/pytest-reserial/commit/0ba54145e8362e187a479f8a61ac553263f7d8fa))
 
 ## [0.3.0] - 2024-02-07
 
@@ -46,6 +63,7 @@ _Maintenance release._
 
 _Initial release._
 
+[0.4.0]: https://github.com/bessman/pytest-reserial/releases/tag/0.4.0
 [0.3.0]: https://github.com/bessman/pytest-reserial/releases/tag/0.3.0
 [0.2.4]: https://github.com/bessman/pytest-reserial/releases/tag/v0.2.4
 [0.2.3]: https://github.com/bessman/pytest-reserial/releases/tag/v0.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.3.1] - Development
+## [0.4.0] - Development
 
 ## [0.3.0] - 2024-02-07
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Next:
 4.  Disconnect the device.
 5.  Run `pytest --replay my_serial_app.py`. The test will pass!
 
-The logged traffic will be stored in JSON files in the same directory as your test files, and will have the same names as the test files except with a .json extension instead of .py. For example, if your project layout is:
+The logged traffic will be stored as JSON Lines, with one file per test file and one line per test, in the same directory as your test files. The files will have the same names as the test files except with a .jsonl extension instead of .py. For example, if your project layout is:
 
 ```shell
 ├── src
@@ -54,7 +54,7 @@ The logged traffic will be stored in JSON files in the same directory as your te
 │   ├── test_myproject.py
 ```
 
-Then after running `pytest --record`, the test/ directory will contain a new file, test_myproject.json, containing the recorded serial traffic from the tests.
+Then after running `pytest --record`, the test/ directory will contain a new file, test_myproject.jsonl, containing the recorded serial traffic from the tests.
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ With pytest-reserial, you don't have to worry about any of that. Just write your
 
 pytest-reserial depends on pytest and pyserial.
 
-If jsbeautifier is installed, each test's recorded traffic is written on a single line in the log files. Otherwise, each recorded byte is written on a separate line.
-
 ## Copyright
 
 MIT License, (C) 2022 Alexander Bessman

--- a/src/pytest_reserial/__init__.py
+++ b/src/pytest_reserial/__init__.py
@@ -1,3 +1,3 @@
 """Pytest fixture for recording and replaying serial port traffic."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/src/pytest_reserial/__init__.py
+++ b/src/pytest_reserial/__init__.py
@@ -1,3 +1,3 @@
 """Pytest fixture for recording and replaying serial port traffic."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/pytest_reserial/update_log.py
+++ b/src/pytest_reserial/update_log.py
@@ -1,0 +1,18 @@
+"""Convert log files created by pytest-reserial<0.4.0 to the new format."""
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+old = Path(sys.argv[1])
+new = Path(old.stem + ".jsonl")
+
+with old.open() as fin:
+    records = json.load(fin)
+
+with new.open("w") as fout:
+    for test_name, data in records.items():
+        rx = base64.b64encode(bytes(data["rx"])).decode("ascii")
+        tx = base64.b64encode(bytes(data["tx"])).decode("ascii")
+        fout.write(json.dumps({test_name: {"rx": rx, "tx": tx}}) + "\n")

--- a/tests/test_reserial.py
+++ b/tests/test_reserial.py
@@ -3,37 +3,31 @@ import json
 from serial import Serial
 
 TEST_RX = b"\x01"
+TEST_RX_ENC = "AQ=="
 TEST_TX = b"\x02"
+TEST_TX_ENC = "Ag=="
 TEST_FILE = f"""
             import serial
             def test_reserial(reserial):
                 s = serial.Serial(port="/dev/ttyUSB0")
-                s.write({TEST_TX})
-                assert s.read() == {TEST_RX}
+                s.write({TEST_TX!r})
+                assert s.read() == {TEST_RX!r}
             def test_reserial2(reserial):
                 s = serial.Serial(port="/dev/ttyUSB0")
-                s.write({TEST_TX})
-                assert s.read() == {TEST_RX}
+                s.write({TEST_TX!r})
+                assert s.read() == {TEST_RX!r}
             """
 TEST_FILE_BAD_TX = f"""
-            import serial
-            def test_reserial(reserial):
-                s = serial.Serial(port="/dev/ttyUSB0")
-                s.write({TEST_RX})
-                assert s.read() == {TEST_RX}
-            """
-TEST_JSON = f"""
-            {{
-                "test_reserial": {{
-                    "rx": {list(TEST_RX)},
-                    "tx": {list(TEST_TX)}
-                }},
-                "test_reserial2": {{
-                    "rx": {list(TEST_RX)},
-                    "tx": {list(TEST_TX)}
-                }}
-            }}
-            """
+                    import serial
+                    def test_reserial(reserial):
+                        s = serial.Serial(port="/dev/ttyUSB0")
+                        s.write({TEST_RX!r})
+                        assert s.read() == {TEST_RX!r}
+                    """
+TEST_JSONL = (
+    f'{{"test_reserial": {{"rx": "{TEST_RX_ENC}", "tx": "{TEST_TX_ENC}"}}}}\n'
+    f'{{"test_reserial2": {{"rx": "{TEST_RX_ENC}", "tx": "{TEST_TX_ENC}"}}}}\n'
+)
 
 
 def test_record(monkeypatch, pytester):
@@ -57,15 +51,63 @@ def test_record(monkeypatch, pytester):
     monkeypatch.setattr(Serial, "close", patch_close)
     result = pytester.runpytest("--record")
 
-    with open("test_record.json", "r") as f:
-        recording = json.load(f)
+    with open("test_record.jsonl", "r") as f:
+        recording = [json.loads(line) for line in f.readlines()]
 
-    assert recording == json.loads(TEST_JSON)
+    expected = [json.loads(line) for line in TEST_JSONL.splitlines()]
+
+    assert recording == expected
+    assert result.ret == 0
+
+
+def test_update_existing(monkeypatch, pytester):
+    pytester.makefile(".jsonl", test_update_existing=TEST_JSONL)
+    pytester.makepyfile(
+        f"""
+        import serial
+        def test_reserial(reserial):
+            s = serial.Serial(port="/dev/ttyUSB0")
+            s.write({2 * TEST_TX})
+            assert s.read() == {2 * TEST_RX}
+        """
+    )
+
+    def patch_write(self: Serial, data: bytes) -> int:
+        return len(data)
+
+    def patch_read(self: Serial, size: int = 1) -> bytes:
+        return 2 * TEST_RX
+
+    def patch_open(self: Serial) -> None:
+        self.is_open = True
+
+    def patch_close(self: Serial) -> None:
+        self.is_open = False
+
+    monkeypatch.setattr(Serial, "write", patch_write)
+    monkeypatch.setattr(Serial, "read", patch_read)
+    monkeypatch.setattr(Serial, "open", patch_open)
+    monkeypatch.setattr(Serial, "close", patch_close)
+    result = pytester.runpytest("--record")
+
+    with open("test_update_existing.jsonl", "r") as f:
+        recording = [json.loads(line) for line in f.readlines()]
+
+    expected_rx_enc = "AQE="
+    expected_tx_enc = "AgI="
+    expected_jsonl = (
+        f'{{"test_reserial": {{"rx": "{expected_rx_enc}", "tx": "{expected_tx_enc}"}}}}\n'
+        f'{{"test_reserial2": {{"rx": "{TEST_RX_ENC}", "tx": "{TEST_TX_ENC}"}}}}\n'
+    )
+
+    expected = [json.loads(line) for line in expected_jsonl.splitlines()]
+
+    assert recording == expected
     assert result.ret == 0
 
 
 def test_replay(pytester):
-    pytester.makefile(".json", test_replay=TEST_JSON)
+    pytester.makefile(".jsonl", test_replay=TEST_JSONL)
     pytester.makepyfile(TEST_FILE)
     result = pytester.runpytest("--replay")
     assert result.ret == 0
@@ -91,7 +133,7 @@ def test_invalid_option(pytester):
 
 
 def test_bad_tx(pytester):
-    pytester.makefile(".json", test_bad_tx=TEST_JSON)
+    pytester.makefile(".jsonl", test_bad_tx=TEST_JSONL)
     pytester.makepyfile(TEST_FILE_BAD_TX)
     result = pytester.runpytest("--replay")
     result.assert_outcomes(errors=1, failed=1)
@@ -111,8 +153,8 @@ def test_help_message(pytester):
 
 def test_change_settings(pytester):
     pytester.makefile(
-        ".json",
-        test_change_settings='{"test_reserial": {"tx": [], "rx": []}}',
+        ".jsonl",
+        test_change_settings='{"test_reserial": {"tx": "", "rx": ""}}',
     )
     pytester.makepyfile(
         """
@@ -124,3 +166,16 @@ def test_change_settings(pytester):
     )
     result = pytester.runpytest("--replay")
     assert result.ret == 0
+
+
+def test_no_traffic_for_test(pytester):
+    pytester.makefile(".jsonl", test_no_traffic_for_test=TEST_JSONL)
+    pytester.makepyfile(
+        """
+            import serial
+            def test_reserial3(reserial):
+                pass
+        """
+    )
+    result = pytester.runpytest("--replay")
+    result.assert_outcomes(errors=1)


### PR DESCRIPTION
Store logged test data as base64 strings in JSON Lines, instead of as lists in JSON.