### PR TITLE
feature: Patch Serial.in_waiting too

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dev = [
     "tox",
 ]
 
+[tool.coverage.report]
+show_missing = true
+
 [tool.isort]
 profile = "black"
 

--- a/src/pytest_reserial/reserial.py
+++ b/src/pytest_reserial/reserial.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterator, Literal, Tuple
 
 import pytest
-from serial import Serial  # type: ignore[import-untyped]
+from serial import PortNotOpenError, Serial  # type: ignore[import-untyped]
 
 TrafficLog = Dict[Literal["rx", "tx"], bytes]
 PatchMethods = Tuple[
@@ -206,6 +206,9 @@ def get_replay_methods(log: TrafficLog) -> PatchMethods:
         _pytest.outcomes.Failed
             If written data does not match recorded data.
         """
+        if not self.is_open:
+            raise PortNotOpenError
+
         if data == log["tx"][: len(data)]:
             log["tx"] = log["tx"][len(data) :]
         else:
@@ -226,6 +229,9 @@ def get_replay_methods(log: TrafficLog) -> PatchMethods:
         Monkeypatch this method over Serial.read to replay traffic. Parameters and
         return values are identical to Serial.read.
         """
+        if not self.is_open:
+            raise PortNotOpenError
+
         data = log["rx"][:size]
         log["rx"] = log["rx"][size:]
         return bytes(data)

--- a/src/pytest_reserial/reserial.py
+++ b/src/pytest_reserial/reserial.py
@@ -210,7 +210,7 @@ def get_replay_methods(log: TrafficLog) -> PatchMethods:
     """
 
     def replay_write(
-        self: Serial,  # noqa: ARG001
+        self: Serial,
         data: bytes,
     ) -> int:
         """Compare TX data to recording instead of writing to the bus.
@@ -238,7 +238,7 @@ def get_replay_methods(log: TrafficLog) -> PatchMethods:
         return len(data)
 
     def replay_read(
-        self: Serial,  # noqa: ARG001
+        self: Serial,
         size: int = 1,
     ) -> bytes:
         """Replay RX data from recording instead of reading from the bus.

--- a/tests/test_reserial.py
+++ b/tests/test_reserial.py
@@ -17,6 +17,24 @@ TEST_FILE = f"""
                 s.write({TEST_TX!r})
                 assert s.read() == {TEST_RX!r}
             """
+TEST_FILE_REPLAY = f"""
+            import pytest
+            import serial
+            def test_reserial(reserial):
+                s = serial.Serial(port="/dev/ttyUSB0")
+                s.write({TEST_TX!r})
+                assert s.read() == {TEST_RX!r}
+                s.close()
+                with pytest.raises(serial.PortNotOpenError):
+                    s.read()
+            def test_reserial2(reserial):
+                s = serial.Serial(port="/dev/ttyUSB0")
+                s.write({TEST_TX!r})
+                assert s.read() == {TEST_RX!r}
+                s.close()
+                with pytest.raises(serial.PortNotOpenError):
+                    s.write({TEST_TX!r})
+            """
 TEST_FILE_BAD_TX = f"""
                     import serial
                     def test_reserial(reserial):
@@ -108,7 +126,7 @@ def test_update_existing(monkeypatch, pytester):
 
 def test_replay(pytester):
     pytester.makefile(".jsonl", test_replay=TEST_JSONL)
-    pytester.makepyfile(TEST_FILE)
+    pytester.makepyfile(TEST_FILE_REPLAY)
     result = pytester.runpytest("--replay")
     assert result.ret == 0
 


### PR DESCRIPTION
Allow replaying serial port interactions that use `Serial.in_waiting`.

+ fix: raise PortNotOpenError on read/write to a closed serial port, so that the replay behavior would be closer to the real one
+ ci: report missing statements in the coverage report, to see what should be tested
+ chore: remove unused noqa directive, to fix the corresponding lint error.